### PR TITLE
Added little endian support

### DIFF
--- a/lppb.lua
+++ b/lppb.lua
@@ -1,6 +1,4 @@
-
 local lppb = Proto("lppb","Length Prefixed Protocol Buffers");
-info("starting")
 len_F = ProtoField.string("lppb.len","Length")
 lppb.fields = {len_F}
 


### PR DESCRIPTION
I'm using a little endian encoded length prefix, and it was not supported in the original version. So I added an config option for little endian decoding.